### PR TITLE
Add empty preferenceDefaults

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -18,5 +18,6 @@
     "file-system"
   ],
   "allowedDomains": ["iina.io", "*.iina.io"],
-  "helpPage": "help.html"
+  "helpPage": "help.html",
+  "preferenceDefaults": {}
 }


### PR DESCRIPTION
iina currently logs a warning if preferenceDefaults isn't defined.

I only care because I'm debugging my own plugin and it's convenient to be able filter the log viewer to warnings and not see any irrelevant messages. (Because iina doesn't log the plugin name in the warning all you see is "2:22:03.342 pm [iina][w] Unable to read preferenceDefaults").